### PR TITLE
Use ubuntu-24.04-arm for GitHub Actions

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   spotless:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
   unit-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 30
     permissions:
       contents: read


### PR DESCRIPTION
This commit updates the `spotless` and `unit-test` GitHub Actions workflows to use `ubuntu-24.04-arm` runners instead of `ubuntu-latest`.