### PR TITLE
Update placeholder text for argument previews

### DIFF
--- a/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/diargsreceiver/DiArgsReceiverScreen.kt
+++ b/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/diargsreceiver/DiArgsReceiverScreen.kt
@@ -36,7 +36,7 @@ private fun DiArgsReceiverScreen(
 private fun DiArgsReceiverScreenPreview() {
     // TODO: Theme
     DiArgsReceiverScreen(
-        arg = "TODO",
+        arg = "Arg",
         onNavigateUpClick = {},
     )
 }

--- a/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/directargsreceiver/DirectArgsReceiverScreen.kt
+++ b/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/directargsreceiver/DirectArgsReceiverScreen.kt
@@ -24,7 +24,7 @@ internal fun DirectArgsReceiverScreen(
 private fun DirectArgsReceiverScreenPreview() {
     // TODO: Theme
     DirectArgsReceiverScreen(
-        arg = "TODO",
+        arg = "Arg",
         onNavigateUpClick = {},
     )
 }

--- a/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/viewmodelargsreceiver/ViewModelArgsReceiverScreen.kt
+++ b/feature/navigationarguments/src/main/kotlin/io/github/daiji256/showcase/feature/navigationarguments/viewmodelargsreceiver/ViewModelArgsReceiverScreen.kt
@@ -36,7 +36,7 @@ private fun ViewModelArgsReceiverScreen(
 private fun ViewModelArgsReceiverScreenPreview() {
     // TODO: Theme
     ViewModelArgsReceiverScreen(
-        arg = "TODO",
+        arg = "Arg",
         onNavigateUpClick = {},
     )
 }


### PR DESCRIPTION
The preview functions for `DiArgsReceiverScreen`, `ViewModelArgsReceiverScreen`, and `DirectArgsReceiverScreen` were updated to use "Arg" instead of "TODO" as the placeholder for the argument value.