### PR TITLE
CI: Improve screenshot test reporting in pull requests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -86,6 +86,8 @@ jobs:
         run: |
           files=$(find . -type f -name "*_compare.png" | sort)
           if [ -n "$files" ]; then
+            echo "<!-- screenshot-test-report -->" >> "$REPORT_FILE"
+            echo "" >> "$REPORT_FILE"
             echo "> [!NOTE]" >> "$REPORT_FILE"
             echo "> Differences found in $(echo "$files" | wc -l) screenshots." >> "$REPORT_FILE"
             echo "" >> "$REPORT_FILE"
@@ -107,13 +109,29 @@ jobs:
           else
             echo "report_present=false" >> "$GITHUB_OUTPUT"
           fi
-
+      - name: Delete outdated report
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          comment_ids=$(
+            gh api "repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" |
+            jq -r '
+              .[]
+              | select(.user.login == "github-actions[bot]")
+              | select(.body | contains("<!-- screenshot-test-report -->"))
+              | .id'
+          )
+          for comment_id in $comment_ids; do
+            gh api -X DELETE "repos/${REPOSITORY}/issues/comments/${comment_id}"
+          done
       - name: Post report
         if: ${{ success() && !cancelled() && steps.create-report.outputs.report_present == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr comment $PR_NUMBER --body-file $REPORT_FILE --edit-last --create-if-none
+        run: gh pr comment $PR_NUMBER --body-file $REPORT_FILE
 
       - name: Delete outdated _companion branches
         run: |


### PR DESCRIPTION
This commit updates the `unit-test.yml` GitHub Actions workflow to enhance how screenshot test results are reported in pull requests.

Specifically, it introduces the following changes:
- Adds a unique HTML comment `<!-- screenshot-test-report -->` to screenshot test report comments.
- Before posting a new report, the workflow now deletes any existing comments on the PR that were posted by `github-actions[bot]` and contain the `<!-- screenshot-test-report -->` marker. This prevents multiple outdated reports from cluttering the PR.
- The `--edit-last --create-if-none` options for `gh pr comment` have been removed, as the new deletion logic ensures only one relevant report is present.