### PR TITLE
Style: Configure Kotlin import layout

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -29,6 +29,15 @@
       <option name="JD_PRESERVE_LINE_FEEDS" value="true" />
     </JavaCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="false" />
+          <package name="javax" alias="false" withSubpackages="false" />
+          <package name="kotlin" alias="false" withSubpackages="false" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="99" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="99" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />


### PR DESCRIPTION
This commit updates the project's code style settings for Kotlin. Specifically, it defines a custom layout for import statements:
- Standard packages (empty package, `java`, `javax`, `kotlin`) are imported first.
- All other packages are imported next, using aliases if necessary.

This change aims to improve code consistency and readability by standardizing the order of import statements.