### PR TITLE
build: consolidate compose compiler metrics and reports into enableCo…

### DIFF
--- a/.github/workflows/compose-stability-check.yml
+++ b/.github/workflows/compose-stability-check.yml
@@ -35,31 +35,29 @@ jobs:
       - name: Copy GitHub Actions gradle.properties
         run: mkdir -p ~/.gradle ; cp .github/gradle.properties ~/.gradle/gradle.properties
 
-      - name: Download base metrics
+      - name: Download base compose-stability
         uses: daiji256/download-from-orphan-branch@d1bdd0b00dbb1dd7145324d93631a5a3226d715d # v1.0.0
         with:
           branch: ${{ needs.orphan-branch-name.outputs.base-report }}
           path: base
 
-      - name: Generate Compose Compiler Reports
+      - name: Generate head compose-stability
         run: |
-          ./gradlew assembleDebug \
-            -PenableComposeCompilerMetrics=true \
-            -PenableComposeCompilerReports=true
+          ./gradlew assembleDebug -PenableComposeStability=true
 
       - name: Generate Report
         run: |
           ./gradlew generateComposeStabilityCheck \
-            -Pbase=base/build/compose-compiler \
-            -Phead=build/compose-compiler \
+            -Pbase=base/build/compose-stability \
+            -Phead=build/compose-stability \
             -Poutput=build/compose-stability-check.md
 
-      - name: Upload head metrics
+      - name: Upload head compose-stability
         uses: daiji256/upload-to-orphan-branch@8d353234c31aaf2134dc6081b863fcd876fcb2d0 # v1.0.0
         with:
           branch: ${{ needs.orphan-branch-name.outputs.head-report }}
           overwrite: true
-          path: "**/build/compose-compiler/**"
+          path: "**/build/compose-stability/**"
 
       - name: Post Report Comment
         env:
@@ -110,19 +108,17 @@ jobs:
         if: ${{ !cancelled() && success() && steps.check-base-report-branch.outputs.exists == 'false' }}
         run: mkdir -p ~/.gradle ; cp .github/gradle.properties ~/.gradle/gradle.properties
 
-      - name: Generate base metrics
+      - name: Generate base compose-stability
         if: ${{ !cancelled() && success() && steps.check-base-report-branch.outputs.exists == 'false' }}
         run: |
-          ./gradlew assembleDebug \
-            -PenableComposeCompilerMetrics=true \
-            -PenableComposeCompilerReports=true
+          ./gradlew assembleDebug -PenableComposeStability=true
 
-      - name: Upload base metrics
+      - name: Upload base compose-stability
         if: ${{ !cancelled() && success() && steps.check-base-report-branch.outputs.exists == 'false' }}
         uses: daiji256/upload-to-orphan-branch@8d353234c31aaf2134dc6081b863fcd876fcb2d0 # v1.0.0
         with:
           branch: ${{ needs.orphan-branch-name.outputs.base-report }}
-          path: "**/build/compose-compiler/**"
+          path: "**/build/compose-stability/**"
 
   orphan-branch-name:
     runs-on: ubuntu-latest

--- a/build-logic/src/main/kotlin/io/github/daiji256/showcase/buildlogic/ComposePlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/daiji256/showcase/buildlogic/ComposePlugin.kt
@@ -32,22 +32,18 @@ class ComposePlugin : Plugin<Project> {
             }
 
             extensions.configure<ComposeCompilerGradlePluginExtension> {
-                val enableMetrics = providers.gradleProperty("enableComposeCompilerMetrics")
-                    .orNull?.toBoolean() ?: false
-                val enableReports = providers.gradleProperty("enableComposeCompilerReports")
+                val enableStability = providers.gradleProperty("enableComposeStability")
                     .orNull?.toBoolean() ?: false
                 val relativePath = projectDir.toRelativeString(rootDir)
-                if (enableMetrics) {
+                if (enableStability) {
                     metricsDestination.set(
                         rootProject.layout.buildDirectory.dir(
-                            "compose-compiler/metrics/$relativePath",
+                            "compose-stability/metrics/$relativePath",
                         ),
                     )
-                }
-                if (enableReports) {
                     reportsDestination.set(
                         rootProject.layout.buildDirectory.dir(
-                            "compose-compiler/reports/$relativePath",
+                            "compose-stability/reports/$relativePath",
                         ),
                     )
                 }


### PR DESCRIPTION
…mposeStability

- Replace `enableComposeCompilerMetrics` and `enableComposeCompilerReports` Gradle properties with a single `enableComposeStability` property.
- Update `ComposePlugin.kt` to output metrics and reports to the `compose-stability` directory when enabled.
- Update the `compose-stability-check.yml` workflow to use the new property and directory paths for generating, uploading, and downloading stability reports.