### PR TITLE
ci: skip compose stability report comment if no changes found

### DIFF
--- a/.github/workflows/compose-stability-check.yml
+++ b/.github/workflows/compose-stability-check.yml
@@ -46,11 +46,17 @@ jobs:
           ./gradlew assembleDebug -PenableComposeStability=true
 
       - name: Generate Report
+        id: generate-report
         run: |
           ./gradlew generateComposeStabilityCheck \
             -Pbase=base/build/compose-stability \
             -Phead=build/compose-stability \
             -Poutput=build/compose-stability-check.md
+          if [ -f build/compose-stability-check.md ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload head compose-stability
         uses: daiji256/upload-to-orphan-branch@8d353234c31aaf2134dc6081b863fcd876fcb2d0 # v1.0.0
@@ -60,6 +66,7 @@ jobs:
           path: "**/build/compose-stability/**"
 
       - name: Post Report Comment
+        if: ${{ !cancelled() && success() && steps.generate-report.outputs.exists == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/build-logic/src/main/kotlin/io/github/daiji256/showcase/buildlogic/ComposeStabilityCheckPlugin.kt
+++ b/build-logic/src/main/kotlin/io/github/daiji256/showcase/buildlogic/ComposeStabilityCheckPlugin.kt
@@ -15,6 +15,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
@@ -50,6 +51,7 @@ abstract class ComposeStabilityCheckTask : DefaultTask() {
     @get:InputDirectory
     abstract val headDir: DirectoryProperty
 
+    @get:Optional
     @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
@@ -109,24 +111,26 @@ abstract class ComposeStabilityCheckTask : DefaultTask() {
             }
         }
 
-        val report = buildString {
-            appendLine("> [!NOTE]")
-            appendLine("> Compose stability changed by +$totalAdded, -$totalRemoved lines.")
-            appendLine()
-            appendLine("<details><summary>Expand for details</summary>")
-            appendLine()
-            appendLine(tables(base = baseMetrics.values.sum(), head = headMetrics.values.sum()))
-            diffs.forEach { diff ->
+        if (diffs.isNotEmpty()) {
+            val report = buildString {
+                appendLine("> [!NOTE]")
+                appendLine("> Compose stability changed by +$totalAdded, -$totalRemoved lines.")
                 appendLine()
-                appendLine("```diff")
-                appendLine(diff)
-                appendLine("```")
+                appendLine("<details><summary>Expand for details</summary>")
+                appendLine()
+                appendLine(tables(base = baseMetrics.values.sum(), head = headMetrics.values.sum()))
+                diffs.forEach { diff ->
+                    appendLine()
+                    appendLine("```diff")
+                    appendLine(diff)
+                    appendLine("```")
+                }
+                appendLine()
+                appendLine("</details>")
             }
-            appendLine()
-            appendLine("</details>")
-        }
 
-        outputFile.get().asFile.writeText(report)
+            outputFile.get().asFile.writeText(report)
+        }
     }
 }
 


### PR DESCRIPTION
- Update `ComposeStabilityCheckPlugin` to only write the output file if stability differences are detected.
- Modify the `compose-stability-check` workflow to check for the report file's existence before attempting to post a PR comment.